### PR TITLE
Log levels rework

### DIFF
--- a/lib/levels/levels.js
+++ b/lib/levels/levels.js
@@ -8,81 +8,69 @@
 
 'use strict';
 
-module.exports = () => {
-    let _level = null;
+const _levelsByLabel = {
+    trace: 10,
+    debug: 20,
+    info: 30,
+    warn: 40,
+    error: 50,
+    fatal: 60,
+    silent: Infinity
+};
 
-    const _levels = {
-        trace: 10,
-        debug: 20,
-        info: 30,
-        warn: 40,
-        error: 50,
-        fatal: 60,
-        silent: Infinity
-    };
+const _levelsByValue = {
+    10: 'trace',
+    20: 'debug',
+    30: 'info',
+    40: 'warn',
+    50: 'error',
+    60: 'fatal',
+    Infinity: 'silent'
+};
 
-    const _levelsByValue = {
-        10: 'trace',
-        20: 'debug',
-        30: 'info',
-        40: 'warn',
-        50: 'error',
-        60: 'fatal',
-        Infinity: 'silent'
-    };
+function getLevel() {
+    return this._level;
+};
 
-    const setLevel = (label, value) => {
-        _level = {
-            get label() {
-                return label;
-            },
-            get value() {
-                return value;
-            }
-        };
-    };
+function setLevel(rawLevel) {
+    if (typeof rawLevel === 'string') {
+        const level = rawLevel.toLowerCase();
 
-    const isLevelEnabled = rawLevel => {
-        if (!_level) {
-            return false;
+        if (_levelsByLabel.hasOwnProperty(level)) {
+            this._level = { label: level, value: _levelsByLabel[level] };
+            return;
         }
+    } else if (typeof rawLevel === 'number' && _levelsByValue.hasOwnProperty(rawLevel)) {
+        this._level = { label: _levelsByValue[rawLevel], value: rawLevel };
+        return;
+    }
 
-        let level;
+    throw new Error('Unknown level');
+};
 
-        if (typeof rawLevel === 'string') {
-            level = rawLevel.toLowerCase();
-        } else if (typeof rawLevel === 'number' && _levelsByValue.hasOwnProperty(rawLevel)) {
-            level = _levelsByValue[rawLevel];
-        }
+function isLevelEnabled(rawLevel) {
+    if (!this._level) {
+        return false;
+    }
 
-        if (level === 'silent') {
-            return _level.label === level;
-        } else {
-            return level && _levels.hasOwnProperty(level) ? _levels[level] >= _levels[_level.label] : false;
-        }
-    };
+    let level;
 
-    return {
-        get level() {
-            return _level;
-        },
-        set level(rawLevel) {
-            if (typeof rawLevel === 'string') {
-                const level = rawLevel.toLowerCase();
-                if (_levels.hasOwnProperty(level)) {
-                    setLevel(level, _levels[level]);
-                    return;
-                }
-            } else if (typeof rawLevel === 'number' && _levelsByValue.hasOwnProperty(rawLevel)) {
-                setLevel(_levelsByValue[rawLevel], rawLevel);
-                return;
-            }
+    if (typeof rawLevel === 'string') {
+        level = rawLevel.toLowerCase();
+    } else if (typeof rawLevel === 'number' && _levelsByValue.hasOwnProperty(rawLevel)) {
+        level = _levelsByValue[rawLevel];
+    }
 
-            throw new Error('Unknown level');
-        },
-        get levels() {
-            return _levels;
-        },
-        isLevelEnabled
-    };
+    if (level === 'silent') {
+        return this._level.label === level;
+    } else {
+        return level && _levelsByLabel.hasOwnProperty(level) ? _levelsByLabel[level] >= _levelsByLabel[this._level.label] : false;
+    }
+};
+
+module.exports = {
+    levels: _levelsByLabel,
+    getLevel,
+    setLevel,
+    isLevelEnabled
 };

--- a/test/unit/maquiavelog.spec.js
+++ b/test/unit/maquiavelog.spec.js
@@ -7,20 +7,17 @@ const expect = chai.expect;
 
 chai.use(require('sinon-chai'));
 
-describe('MaquiaveLog', () => {
+describe('Maquiavelog', () => {
     let maquiavelog;
 
     beforeEach(() =>{
         maquiavelog = Maquiavelog();
-        sinon.stub(process.stdout, 'write').callsFake(chunk => {});
-    });
-
-    afterEach(() => {
-        sinon.restore();
     });
 
     it('logs info("Hello World")', () => {
+        sinon.stub(process.stdout, 'write').callsFake(chunk => {});
         maquiavelog.info('Hello world!');
         expect(process.stdout.write).to.have.been.calledOnceWith('Hello world!');
+        sinon.restore();
     });
 });


### PR DESCRIPTION
This PR refactors the levels module to export an object instead of a factory function. This will facilitate its integration with the whole logger instance once all the other modules are finished.